### PR TITLE
Relax compiler pinning to support gcc 13.

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -69,6 +69,13 @@ else
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
+
+    ( startgroup "Inspecting artifacts" ) 2> /dev/null
+
+    # inspect_artifacts was only added in conda-forge-ci-setup 4.6.0
+    command -v inspect_artifacts >/dev/null 2>&1 && inspect_artifacts || echo "inspect_artifacts needs conda-forge-ci-setup >=4.6.0"
+
+    ( endgroup "Inspecting artifacts" ) 2> /dev/null
     ( startgroup "Validating outputs" ) 2> /dev/null
 
     validate_recipe_outputs "${FEEDSTOCK_NAME}"

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -53,6 +53,11 @@ echo Building recipe
 conda-build.exe "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
 if !errorlevel! neq 0 exit /b !errorlevel!
 
+call :start_group "Inspecting artifacts"
+:: inspect_artifacts was only added in conda-forge-ci-setup 4.6.0
+WHERE inspect_artifacts >nul 2>nul && inspect_artifacts || echo "inspect_artifacts needs conda-forge-ci-setup >=4.6.0"
+call :end_group
+
 :: Prepare some environment variables for the upload step
 if /i "%CI%" == "github_actions" (
     set "FEEDSTOCK_NAME=%GITHUB_REPOSITORY:*/=%"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ source:
     - nvcc.profile.patch.win  # [win]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [osx or ppc64le]
 
 outputs:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,8 +2,8 @@
 {% set version = "12.5.40" %}
 {% set cuda_version = "12.5" %}
 {% set cuda_version_next_major = (cuda_version.split(".")[0]|int + 1)|string + ".0a0" %}
-{% set gcc_min_pin = ">=6" %}
-{% set gcc_pin = ">=6,<14.0a0" %}
+{% set gcc_min_constraint = ">=6" %}
+{% set gcc_constraint = ">=6,<14.0a0" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]
 {% set platform = "linux-sbsa" %}  # [aarch64]
@@ -53,7 +53,7 @@ outputs:
         - {{ pin_subpackage("cuda-crt-tools", exact=True) }}
         - {{ pin_subpackage("cuda-nvvm-tools", exact=True) }}
       run_constrained:
-        - gcc_impl_{{ target_platform }} {{ gcc_pin }}  # [linux]
+        - gcc_impl_{{ target_platform }} {{ gcc_constraint }}  # [linux]
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
       commands:
@@ -96,14 +96,14 @@ outputs:
         - {{ pin_subpackage("cuda-nvcc-tools", exact=True) }}
         - {{ pin_subpackage("cuda-crt-dev_" + target_platform, exact=True) }}
         - {{ pin_subpackage("cuda-nvvm-dev_" + target_platform, exact=True) }}
-        - libgcc-ng {{ gcc_min_pin }}  # [linux]
+        - libgcc-ng {{ gcc_min_constraint }}  # [linux]
       run:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
         - {{ pin_subpackage("cuda-crt-dev_" + target_platform, exact=True) }}
         - {{ pin_subpackage("cuda-nvvm-dev_" + target_platform, exact=True) }}
-        - libgcc-ng {{ gcc_min_pin }}  # [linux]
+        - libgcc-ng {{ gcc_min_constraint }}  # [linux]
       run_constrained:
-        - gcc_impl_{{ target_platform }} {{ gcc_pin }}  # [linux]
+        - gcc_impl_{{ target_platform }} {{ gcc_constraint }}  # [linux]
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
       commands:
@@ -149,7 +149,7 @@ outputs:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
         - cuda-cudart-dev
       run_constrained:
-        - gcc_impl_{{ target_platform }} {{ gcc_pin }}  # [linux]
+        - gcc_impl_{{ target_platform }} {{ gcc_constraint }}  # [linux]
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
         - vc >={{ VCVER }}                      # [win]
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,7 +51,7 @@ outputs:
         - {{ pin_subpackage("cuda-crt-tools", exact=True) }}
         - {{ pin_subpackage("cuda-nvvm-tools", exact=True) }}
       run_constrained:
-        - gcc_impl_{{ target_platform }} >=6,<13.3a0  # [linux]
+        - gcc_impl_{{ target_platform }} >=6,<14.0a0  # [linux]
         - arm-variant * {{ arm_variant_type }}        # [aarch64]
     test:
       commands:
@@ -101,7 +101,7 @@ outputs:
         - {{ pin_subpackage("cuda-nvvm-dev_" + target_platform, exact=True) }}
         - libgcc-ng >=6                         # [linux]
       run_constrained:
-        - gcc_impl_{{ target_platform }} >=6,<13.3a0  # [linux]
+        - gcc_impl_{{ target_platform }} >=6,<14.0a0  # [linux]
         - arm-variant * {{ arm_variant_type }}        # [aarch64]
     test:
       commands:
@@ -147,7 +147,7 @@ outputs:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
         - cuda-cudart-dev
       run_constrained:
-        - gcc_impl_{{ target_platform }} >=6,<13.3a0  # [linux]
+        - gcc_impl_{{ target_platform }} >=6,<14.0a0  # [linux]
         - arm-variant * {{ arm_variant_type }}        # [aarch64]
         - vc >={{ VCVER }}                            # [win]
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,6 +2,8 @@
 {% set version = "12.5.40" %}
 {% set cuda_version = "12.5" %}
 {% set cuda_version_next_major = (cuda_version.split(".")[0]|int + 1)|string + ".0a0" %}
+{% set gcc_lower_bound = ">=6" %}
+{% set gcc_upper_bound = "<14.0a0" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]
 {% set platform = "linux-sbsa" %}  # [aarch64]
@@ -51,8 +53,8 @@ outputs:
         - {{ pin_subpackage("cuda-crt-tools", exact=True) }}
         - {{ pin_subpackage("cuda-nvvm-tools", exact=True) }}
       run_constrained:
-        - gcc_impl_{{ target_platform }} >=6,<14.0a0  # [linux]
-        - arm-variant * {{ arm_variant_type }}        # [aarch64]
+        - gcc_impl_{{ target_platform }} {{ gcc_lower_bound }},{{ gcc_upper_bound }}  # [linux]
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
       commands:
         - test -f $PREFIX/bin/nvcc                                # [linux]
@@ -94,15 +96,15 @@ outputs:
         - {{ pin_subpackage("cuda-nvcc-tools", exact=True) }}
         - {{ pin_subpackage("cuda-crt-dev_" + target_platform, exact=True) }}
         - {{ pin_subpackage("cuda-nvvm-dev_" + target_platform, exact=True) }}
-        - libgcc-ng >=6                         # [linux]
+        - libgcc-ng {{ gcc_lower_bound }}       # [linux]
       run:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
         - {{ pin_subpackage("cuda-crt-dev_" + target_platform, exact=True) }}
         - {{ pin_subpackage("cuda-nvvm-dev_" + target_platform, exact=True) }}
-        - libgcc-ng >=6                         # [linux]
+        - libgcc-ng {{ gcc_lower_bound }}       # [linux]
       run_constrained:
-        - gcc_impl_{{ target_platform }} >=6,<14.0a0  # [linux]
-        - arm-variant * {{ arm_variant_type }}        # [aarch64]
+        - gcc_impl_{{ target_platform }} {{ gcc_lower_bound }},{{ gcc_upper_bound }}  # [linux]
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
       commands:
         - test -L $PREFIX/targets/{{ target_name }}/bin/nvcc      # [linux]
@@ -147,9 +149,9 @@ outputs:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
         - cuda-cudart-dev
       run_constrained:
-        - gcc_impl_{{ target_platform }} >=6,<14.0a0  # [linux]
-        - arm-variant * {{ arm_variant_type }}        # [aarch64]
-        - vc >={{ VCVER }}                            # [win]
+        - gcc_impl_{{ target_platform }} {{ gcc_lower_bound }},{{ gcc_upper_bound }}  # [linux]
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        - vc >={{ VCVER }}                      # [win]
     test:
       requires:
         - {{ compiler("c") }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,8 +51,8 @@ outputs:
         - {{ pin_subpackage("cuda-crt-tools", exact=True) }}
         - {{ pin_subpackage("cuda-nvvm-tools", exact=True) }}
       run_constrained:
-        - gcc_impl_{{ target_platform }} >=6,<13  # [linux]
-        - arm-variant * {{ arm_variant_type }}    # [aarch64]
+        - gcc_impl_{{ target_platform }} >=6,<13.3a0  # [linux]
+        - arm-variant * {{ arm_variant_type }}        # [aarch64]
     test:
       commands:
         - test -f $PREFIX/bin/nvcc                                # [linux]
@@ -101,8 +101,8 @@ outputs:
         - {{ pin_subpackage("cuda-nvvm-dev_" + target_platform, exact=True) }}
         - libgcc-ng >=6                         # [linux]
       run_constrained:
-        - gcc_impl_{{ target_platform }} >=6,<13  # [linux]
-        - arm-variant * {{ arm_variant_type }}    # [aarch64]
+        - gcc_impl_{{ target_platform }} >=6,<13.3a0  # [linux]
+        - arm-variant * {{ arm_variant_type }}        # [aarch64]
     test:
       commands:
         - test -L $PREFIX/targets/{{ target_name }}/bin/nvcc      # [linux]
@@ -147,9 +147,9 @@ outputs:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
         - cuda-cudart-dev
       run_constrained:
-        - gcc_impl_{{ target_platform }} >=6,<13  # [linux]
-        - arm-variant * {{ arm_variant_type }}    # [aarch64]
-        - vc >={{ VCVER }}                        # [win]
+        - gcc_impl_{{ target_platform }} >=6,<13.3a0  # [linux]
+        - arm-variant * {{ arm_variant_type }}        # [aarch64]
+        - vc >={{ VCVER }}                            # [win]
     test:
       requires:
         - {{ compiler("c") }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,8 +2,8 @@
 {% set version = "12.5.40" %}
 {% set cuda_version = "12.5" %}
 {% set cuda_version_next_major = (cuda_version.split(".")[0]|int + 1)|string + ".0a0" %}
-{% set gcc_lower_bound = ">=6" %}
-{% set gcc_upper_bound = "<14.0a0" %}
+{% set gcc_min_pin = ">=6" %}
+{% set gcc_pin = ">=6,<14.0a0" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]
 {% set platform = "linux-sbsa" %}  # [aarch64]
@@ -53,7 +53,7 @@ outputs:
         - {{ pin_subpackage("cuda-crt-tools", exact=True) }}
         - {{ pin_subpackage("cuda-nvvm-tools", exact=True) }}
       run_constrained:
-        - gcc_impl_{{ target_platform }} {{ gcc_lower_bound }},{{ gcc_upper_bound }}  # [linux]
+        - gcc_impl_{{ target_platform }} {{ gcc_pin }}  # [linux]
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
       commands:
@@ -96,14 +96,14 @@ outputs:
         - {{ pin_subpackage("cuda-nvcc-tools", exact=True) }}
         - {{ pin_subpackage("cuda-crt-dev_" + target_platform, exact=True) }}
         - {{ pin_subpackage("cuda-nvvm-dev_" + target_platform, exact=True) }}
-        - libgcc-ng {{ gcc_lower_bound }}       # [linux]
+        - libgcc-ng {{ gcc_min_pin }}  # [linux]
       run:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
         - {{ pin_subpackage("cuda-crt-dev_" + target_platform, exact=True) }}
         - {{ pin_subpackage("cuda-nvvm-dev_" + target_platform, exact=True) }}
-        - libgcc-ng {{ gcc_lower_bound }}       # [linux]
+        - libgcc-ng {{ gcc_min_pin }}  # [linux]
       run_constrained:
-        - gcc_impl_{{ target_platform }} {{ gcc_lower_bound }},{{ gcc_upper_bound }}  # [linux]
+        - gcc_impl_{{ target_platform }} {{ gcc_pin }}  # [linux]
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
       commands:
@@ -149,7 +149,7 @@ outputs:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
         - cuda-cudart-dev
       run_constrained:
-        - gcc_impl_{{ target_platform }} {{ gcc_lower_bound }},{{ gcc_upper_bound }}  # [linux]
+        - gcc_impl_{{ target_platform }} {{ gcc_pin }}  # [linux]
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
         - vc >={{ VCVER }}                      # [win]
     test:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Resolves #21.
