### PR TITLE
Revert "BLD: Drop arm-variant from requirements/run* because it is ex…

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ source:
     - nvcc.profile.patch.win  # [win]
 
 build:
-  number: 1
+  number: 2
   binary_relocation: false
   skip: true  # [osx or ppc64le]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ source:
     - nvcc.profile.patch.win  # [win]
 
 build:
-  number: 2
+  number: 3
   binary_relocation: false
   skip: true  # [osx or ppc64le]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,14 +56,15 @@ outputs:
         - {{ compiler("cxx") }}
         - {{ stdlib("c") }}
       host:
-        - arm-variant * {{ arm_variant_type }}  # [aarch64]
-        - cuda-version {{ cuda_version }}
         - {{ pin_subpackage("cuda-crt-tools", exact=True) }}
         - {{ pin_subpackage("cuda-nvvm-tools", exact=True) }}
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        - cuda-version {{ cuda_version }}
       run:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
         - {{ pin_subpackage("cuda-crt-tools", exact=True) }}
         - {{ pin_subpackage("cuda-nvvm-tools", exact=True) }}
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
       run_constrained:
         - gcc_impl_{{ target_platform }} {{ gcc_constraint }}  # [linux]
     test:
@@ -108,16 +109,17 @@ outputs:
       build:
         - {{ stdlib("c") }}
       host:
+        - {{ pin_subpackage("cuda-crt-dev_" + target_platform, exact=True) }}
+        - {{ pin_subpackage("cuda-nvcc-tools", exact=True) }}
+        - {{ pin_subpackage("cuda-nvvm-dev_" + target_platform, exact=True) }}
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
         - cuda-version {{ cuda_version }}
-        - {{ pin_subpackage("cuda-nvcc-tools", exact=True) }}
-        - {{ pin_subpackage("cuda-crt-dev_" + target_platform, exact=True) }}
-        - {{ pin_subpackage("cuda-nvvm-dev_" + target_platform, exact=True) }}
         - libgcc {{ gcc_min_constraint }}  # [linux]
       run:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
         - {{ pin_subpackage("cuda-crt-dev_" + target_platform, exact=True) }}
         - {{ pin_subpackage("cuda-nvvm-dev_" + target_platform, exact=True) }}
+        - arm-variant * {{ arm_variant_type }}    # [aarch64]
         - libgcc {{ gcc_min_constraint }}  # [linux]
       run_constrained:
         - gcc_impl_{{ target_platform }} {{ gcc_constraint }}  # [linux]
@@ -152,15 +154,16 @@ outputs:
       - lib/libnvptxcompiler_static.a  # [linux]
     requirements:
       host:
-        - arm-variant * {{ arm_variant_type }}  # [aarch64]
-        - cuda-version {{ cuda_version }}
-        - cuda-cudart-dev
         - {{ pin_subpackage("cuda-nvvm-impl", exact=True) }}
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        - cuda-cudart-dev
+        - cuda-version {{ cuda_version }}
       run:
         - {{ pin_subpackage("cuda-nvcc-tools", exact=True) }}
         - {{ pin_subpackage("cuda-nvcc-dev_" + target_platform, exact=True) }}
         - {{ pin_subpackage("cuda-nvvm-impl", exact=True) }}
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
         - cuda-cudart-dev
       run_constrained:
         - gcc_impl_{{ target_platform }} {{ gcc_constraint }}  # [linux]
@@ -203,10 +206,10 @@ outputs:
       - Library\bin\crt  # [win]
     requirements:
       host:
-        - arm-variant * {{ arm_variant_type }}  # [aarch64]
         - cuda-version {{ cuda_version }}
       run:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
+        - arm-variant * {{ arm_variant_type }}    # [aarch64]
     test:
       commands:
         - test -d $PREFIX/bin/crt            # [linux]
@@ -233,10 +236,10 @@ outputs:
       - Library\include\crt                    # [win]
     requirements:
       host:
-        - arm-variant * {{ arm_variant_type }}  # [aarch64]
         - cuda-version {{ cuda_version }}
       run:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
+        - arm-variant * {{ arm_variant_type }}    # [aarch64]
     test:
       commands:
         - test -f $PREFIX/targets/{{ target_name }}/include/crt/common_functions.h  # [linux]
@@ -263,10 +266,10 @@ outputs:
         - {{ compiler("cxx") }}
         - {{ stdlib("c") }}
       host:
-        - arm-variant * {{ arm_variant_type }}  # [aarch64]
         - cuda-version {{ cuda_version }}
       run:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
+        - arm-variant * {{ arm_variant_type }}    # [aarch64]
     test:
       requires:
         - patchelf                                                # [linux]
@@ -295,10 +298,10 @@ outputs:
       - targets/{{ target_name }}/nvvm  # [linux]
     requirements:
       host:
-        - arm-variant * {{ arm_variant_type }}  # [aarch64]
         - cuda-version {{ cuda_version }}
       run:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
+        - arm-variant * {{ arm_variant_type }}    # [aarch64]
     test:
       commands:
         - test -L $PREFIX/targets/{{ target_name }}/nvvm          # [linux]
@@ -327,10 +330,10 @@ outputs:
         - {{ compiler("cxx") }}
         - {{ stdlib("c") }}
       host:
-        - arm-variant * {{ arm_variant_type }}  # [aarch64]
         - cuda-version {{ cuda_version }}
       run:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
+        - arm-variant * {{ arm_variant_type }}    # [aarch64]
     test:
       requires:
         - patchelf                                                # [linux]


### PR DESCRIPTION
…ported from arm-variant in host"

This reverts commit 41f4d33bbc66810b95e3c4e384205b528158b373.

run_exports are not honored for noarch packages, so we must explicitly add dependency on arm-variant

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Edit by @jakirkham - xref: https://github.com/conda-forge/cuda-nvcc-impl-feedstock/pull/35